### PR TITLE
Finding photoIds in users with more than 500 sets

### DIFF
--- a/src/PhotosApi.php
+++ b/src/PhotosApi.php
@@ -127,7 +127,7 @@ class PhotosApi extends ApiMethodGroup
         
         // for users with more than 500 albums, we must search the photoId page by page (thanks, Flickr...)
         foreach (range(1, $sets['pages']) as $pageNum) {
-            if ($pageNum > 1){
+            if ($pageNum > 1) {
                 // download the next page of photosets to search
                 $sets = $this->flickr->photosets()->getList(
                     $userId,

--- a/src/PhotosApi.php
+++ b/src/PhotosApi.php
@@ -124,10 +124,27 @@ class PhotosApi extends ApiMethodGroup
         if (!isset($sets['photoset'])) {
             return false;
         }
-        foreach ($sets['photoset'] as $photoset) {
-            foreach ($photoIds as $photoId) {
-                if (in_array($photoId, $photoset['has_requested_photos'])) {
-                    $out[] = $photoset;
+        
+        // for users with more than 500 albums, we must search the photoId page by page (thanks, Flickr...)
+        foreach (range(1,$sets['pages']) as $count) {
+            if ($count == 1){
+                // do not redownload the first page
+                $sets = $sets;
+            } else {
+                // download the next page of photosets to search
+                $sets = $this->flickr->photosets()->getList(
+                    $userId,
+                    $count,
+                    null,
+                    null,
+                    $photoIdsString
+                    );
+            }
+            foreach ($sets['photoset'] as $photoset) {
+                foreach ($photoIds as $photoId) {
+                    if (in_array($photoId, $photoset['has_requested_photos'])) {
+                        $out[] = $photoset;
+                    }
                 }
             }
         }

--- a/src/PhotosApi.php
+++ b/src/PhotosApi.php
@@ -126,19 +126,16 @@ class PhotosApi extends ApiMethodGroup
         }
         
         // for users with more than 500 albums, we must search the photoId page by page (thanks, Flickr...)
-        foreach (range(1,$sets['pages']) as $count) {
-            if ($count == 1){
-                // do not redownload the first page
-                $sets = $sets;
-            } else {
+        foreach (range(1, $sets['pages']) as $pageNum) {
+            if ($pageNum > 1){
                 // download the next page of photosets to search
                 $sets = $this->flickr->photosets()->getList(
                     $userId,
-                    $count,
+                    $pageNum,
                     null,
                     null,
                     $photoIdsString
-                    );
+                );
             }
             foreach ($sets['photoset'] as $photoset) {
                 foreach ($photoIds as $photoId) {


### PR DESCRIPTION
Flickr users with more than 500 sets will find that photos located in sets beyond the first 500 sets will show up as "no sets" matching. This patch fixes that by scanning the remaining sets if there are multiple pages present. Sadly, flickr provides no way to ordering the sets across pages, or only returning sets that contain the matched photoID. This is the best solution I could find (quickly).