### PR TITLE
Fix for call to undefined method in PhotosApi->getAllContexts().

### DIFF
--- a/src/PhotosApi.php
+++ b/src/PhotosApi.php
@@ -94,7 +94,7 @@ class PhotosApi extends ApiMethodGroup
      */
     public function getAllContexts($photoId)
     {
-        return $this->request('flickr.photos.getAllContexts', ['photo_id' => $photoId]);
+        return $this->flickr->request('flickr.photos.getAllContexts', ['photo_id' => $photoId]);
     }
 
     /**


### PR DESCRIPTION
```
Error: Call to undefined method Samwilson\PhpFlickr\PhotosApi::request() in
Samwilson\PhpFlickr\PhotosApi->getAllContexts() (line 97 of /[path]/vendor/samwilson/phpflickr/src/PhotosApi.php).
```

This PR matches where the request method can be found with the other API calls.