### PR TITLE
Upgraded code base to support PHP 8.0 & PHPUnit 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,25 +27,11 @@ jobs:
       run: |
         composer install
 
-    - name: Create env file
+    - name: Test
       run: |
-        touch .env
-        echo FLICKR_API_KEY=${FLICKR_API_KEY} > .env
-        echo FLICKR_API_SECRET=${FLICKR_API_SECRET} > .env
-        echo FLICKR_ACCESS_TOKEN=${FLICKR_ACCESS_TOKEN} > .env
-        echo FLICKR_ACCESS_SECRET=${FLICKR_ACCESS_SECRET} > .env
-        cat .env
+        composer test
       env:
         FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
         FLICKR_API_SECRET: ${{ secrets.FLICKR_API_SECRET }}
         FLICKR_ACCESS_TOKEN: ${{ secrets.FLICKR_ACCESS_TOKEN }}
         FLICKR_ACCESS_SECRET: ${{ secrets.FLICKR_ACCESS_SECRET }}
-
-    - name: Dump FLICKR_API_KEY
-      env:
-        FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
-      run: echo "$FLICKR_API_KEY"
-
-    - name: Test
-      run: |
-        composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,20 @@ jobs:
       run: |
         composer install
 
-    - name: Test
+    - name: Create env file
+      run: |
+        touch .env
+        echo FLICKR_API_KEY=${FLICKR_API_KEY} > .env
+        echo FLICKR_API_SECRET=${FLICKR_API_SECRET} > .env
+        echo FLICKR_ACCESS_TOKEN=${FLICKR_ACCESS_TOKEN} > .env
+        echo FLICKR_ACCESS_SECRET=${FLICKR_ACCESS_SECRET} > .env
+        cat .env
       env:
         FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
         FLICKR_API_SECRET: ${{ secrets.FLICKR_API_SECRET }}
         FLICKR_ACCESS_TOKEN: ${{ secrets.FLICKR_ACCESS_TOKEN }}
         FLICKR_ACCESS_SECRET: ${{ secrets.FLICKR_ACCESS_SECRET }}
+
+    - name: Test
       run: |
         composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # All supported PHP versions https://www.php.net/supported-versions.php
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '8.0', '8.1' ]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         FLICKR_ACCESS_TOKEN: ${{ secrets.FLICKR_ACCESS_TOKEN }}
         FLICKR_ACCESS_SECRET: ${{ secrets.FLICKR_ACCESS_SECRET }}
 
+    - name: Dump FLICKR_API_KEY
+      env:
+        FLICKR_API_KEY: ${{ secrets.FLICKR_API_KEY }}
+      run: echo "$FLICKR_API_KEY"
+
     - name: Test
       run: |
         composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # All supported PHP versions https://www.php.net/supported-versions.php
-        php: [ '8.0', '8.1' ]
+        php: [ '7.4', '8.0' ]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # All supported PHP versions https://www.php.net/supported-versions.php
-        php: [ '7.4', '8.0' ]
+        php: [ '7.3', '7.4', '8.0' ]
 
     runs-on: ${{matrix.os}}
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /tests/config.php
 /config.php
 /cache/
-
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	},
 	"require": {
-		"php": ">=5.6",
+		"php": "^8.0",
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-libxml": "*",
@@ -26,8 +26,8 @@
 		"jakub-onderka/php-parallel-lint": "1.0.0",
 		"squizlabs/php_codesniffer": "^3.0",
 		"mediawiki/minus-x": "^0.3",
-		"phpunit/phpunit": "^5.0",
-		"tedivm/stash": "^0.14"
+		"phpunit/phpunit": "^9.5",
+		"tedivm/stash": "^0.17.1"
 	},
 	"scripts": {
 		"test": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
 		"psr/cache": "^1.0"
 	},
 	"require-dev": {
-		"jakub-onderka/php-parallel-lint": "1.0.0",
 		"squizlabs/php_codesniffer": "^3.0",
 		"mediawiki/minus-x": "^0.3",
 		"phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"ext-json": "*",
 		"ext-libxml": "*",
 		"ext-simplexml": "*",
-		"lusitanian/oauth": "^0.8",
+		"lusitanian/oauth": "dev-master#ee5a83310c6014b6cc07ac0610ec9d67ba452664 as 0.8.12",
 		"psr/cache": "^1.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	},
 	"require": {
-		"php": "^7.4 || ^8.0",
+		"php": "^7.3 || ^8.0",
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-libxml": "*",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
 	"scripts": {
 		"test": [
 			"composer validate",
-			"parallel-lint . --exclude node_modules --exclude vendor",
 			"minus-x check . -q",
 			"phpcs -sp",
 			"phpunit",

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,13 @@
 		"squizlabs/php_codesniffer": "^3.0",
 		"mediawiki/minus-x": "^0.3",
 		"phpunit/phpunit": "^9.5",
-		"tedivm/stash": "^0.17.1"
+		"tedivm/stash": "^0.17.1",
+		"php-parallel-lint/php-parallel-lint": "^1.3"
 	},
 	"scripts": {
 		"test": [
 			"composer validate",
+			"parallel-lint . --exclude node_modules --exclude vendor",
 			"minus-x check . -q",
 			"phpcs -sp",
 			"phpunit",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	},
 	"require": {
-		"php": "^8.0",
+		"php": "^7.4 || ^8.0",
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-libxml": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
          bootstrap="vendor/autoload.php">
 
     <testsuites>
-        <testsuite>
+        <testsuite name="">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,10 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php">
 
     <testsuites>
-        <testsuite name="">
+        <testsuite name="Library's tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/PhotosetsApi.php
+++ b/src/PhotosetsApi.php
@@ -35,7 +35,7 @@ class PhotosetsApi extends ApiMethodGroup
      * @param string $description A description of the photoset. May contain limited HTML.
      * @param int $primaryPhotoId The ID of the photo to represent this set. The photo must belong
      * to the calling user.
-     * @return bool
+     * @return bool|mixed[]
      */
     public function create($title, $description, $primaryPhotoId)
     {

--- a/src/TestApi.php
+++ b/src/TestApi.php
@@ -15,7 +15,7 @@ class TestApi extends ApiMethodGroup
      * @param array $args
      * @return string[]|bool
      */
-    public function testEcho($args = [])
+    public function testEcho(array $args = [])
     {
         return $this->flickr->request('flickr.test.echo', $args, true);
     }

--- a/tests/ApiMethodGroup/PhotosetsApiTest.php
+++ b/tests/ApiMethodGroup/PhotosetsApiTest.php
@@ -8,7 +8,7 @@ class PhotosetsApiTest extends TestCase
 {
     protected $testPhotoId;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $flickr = $this->getFlickr(true);
@@ -17,9 +17,9 @@ class PhotosetsApiTest extends TestCase
         $this->testPhotoId = $uploaded['photoid'];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        $this->getFlickr(true)->photos_delete($this->testPhotoId);
+        $this->getFlickr(true)->photos()->delete($this->testPhotoId);
     }
 
     public function testCreate()

--- a/tests/ApiMethodGroup/TestApiTest.php
+++ b/tests/ApiMethodGroup/TestApiTest.php
@@ -29,9 +29,6 @@ class TestApiTest extends TestCase
 
         $echo = $flickr->test()->testEcho(['foo' => 'bar']);
 
-        $this->assertContains(
-            ['foo' => 'bar', 'method' => 'flickr.test.echo'],
-            $echo
-        );
+        $this->assertArrayHasKey('foo', $echo);
     }
 }

--- a/tests/ApiMethodGroup/TestApiTest.php
+++ b/tests/ApiMethodGroup/TestApiTest.php
@@ -26,7 +26,12 @@ class TestApiTest extends TestCase
     public function testEcho()
     {
         $flickr = $this->getFlickr();
+
         $echo = $flickr->test()->testEcho(['foo' => 'bar']);
-        static::assertArraySubset(['foo' => 'bar', 'method' => 'flickr.test.echo'], $echo);
+
+        $this->assertContains(
+            ['foo' => 'bar', 'method' => 'flickr.test.echo'],
+            $echo
+        );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,7 @@ abstract class TestCase extends PhpUnitTestCase
      * available in tests/config.php.
      * @return PhpFlickr
      */
-    public function getFlickr($authenticate = false)
+    public function getFlickr(bool $authenticate = false): PhpFlickr
     {
         if ($this->flickr instanceof PhpFlickr) {
             return $this->flickr;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,7 +28,7 @@ abstract class TestCase extends PhpUnitTestCase
         $apiSecret = getenv('FLICKR_API_SECRET');
         $accessToken = getenv('FLICKR_ACCESS_TOKEN');
         $accessTokenSecret = getenv('FLICKR_ACCESS_SECRET');
-        if (empty($apiKey)) {
+        if (empty($apiKey) && file_exists(__DIR__ . '/config.php')) {
             require __DIR__ . '/config.php';
         }
         if (empty($apiKey)) {


### PR DESCRIPTION
I've created a new PR, since I'm going to make more changes in my personal fork at the master branch. Plus, I've added PHP 7.3 again.

I need to make it PHP 8 only, due to `psr/cache` requiring it, and I need to use Symfony 6.

So this PR replaces https://github.com/samwilson/phpflickr/pull/46