### PR TITLE
Update psr/cache requirment to include v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
 		"ext-libxml": "*",
 		"ext-simplexml": "*",
 		"carlos-mg89/oauth": "^0.8",
-		"psr/cache": "^1.0"
+		"psr/cache": "^1.0|^2.0|^3.0"
 	},
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^3.0",
 		"mediawiki/minus-x": "^0.3 || ^1.0",
 		"phpunit/phpunit": "^9.5",
-		"tedivm/stash": "^0.17.1",
+		"symfony/cache": "^5.4",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"phan/phan": "^5.4"
 	},

--- a/examples/caching.php
+++ b/examples/caching.php
@@ -10,8 +10,8 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Make sure we have the required configuration values.
 $configFile = __DIR__ . '/config.php';
 require_once $configFile;
-if (empty($apiKey) || empty($apiSecret) || empty($accessToken) || empty($accessTokenSecret)) {
-    echo 'Please set $apiKey, $apiSecret, $accessToken, and $accessTokenSecret in ' . $configFile;
+if (empty($apiKey) || empty($apiSecret)) {
+    echo 'Please set $apiKey and $apiSecret in ' . $configFile;
     exit(1);
 }
 
@@ -22,9 +22,8 @@ echo "No caching:\n";
 sendRequests($flickr);
 
 // Now add a cache.
-$driver = new Stash\Driver\FileSystem([ 'path' => __DIR__ . '/cache' ]);
-$pool = new Stash\Pool($driver);
-$flickr->setCache($pool);
+$cache = new Symfony\Component\Cache\Adapter\FilesystemAdapter('PhpFlickr', 0, __DIR__ . '/cache/');
+$flickr->setCache($cache);
 
 // Now send the same requests, and the second of them should be much faster.
 echo "With caching:\n";
@@ -38,7 +37,7 @@ function sendRequests(\Samwilson\PhpFlickr\PhpFlickr $flickr)
 {
     for ($i = 1; $i <= 3; $i++) {
         $start = microtime(true);
-        $flickr->test_echo([]);
+        $flickr->request('flickr.test.echo');
         echo "  $i.  " . number_format(microtime(true) - $start, 3) . "\n";
     }
 }


### PR DESCRIPTION
Also updates the cache implementation used in the example file because tedvium/stash doesn't yet support the new versions of psr/cacche.

Fix a bug with the cache example which was using the 'test' API call, which declares itself as 'nocache'. Instead, call it manually (with the default of nocache=false).

Refs #55