### PR TITLE
Fix some calls to deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Now, you can pass the storage into PhpFlickr, and start making requests:
 
 ```php
 $flickr->setOauthStorage($storage);
-$recent = $phpFlickr->photos_getContactsPhotos();
+$recent = $phpFlickr->photos()->getContactsPhotos();
 ```
 
 See the [Usage section](#usage) above for more details on the request methods,

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 		"mediawiki/minus-x": "^0.3 || ^1.0",
 		"phpunit/phpunit": "^9.5",
 		"symfony/cache": "^5.4",
+		"symfony/var-dumper": "^5.4",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"phan/phan": "^5.4"
 	},

--- a/examples/recent_photos.php
+++ b/examples/recent_photos.php
@@ -41,7 +41,7 @@ $recent = $phpFlickr->photos()->getRecent([], 10);
 // Display a list of photo titles.
 echo '<ul>';
 foreach ($recent as $photo) {
-    $owner = $phpFlickr->people_getInfo($photo['owner']);
+    $owner = $phpFlickr->people()->getInfo($photo['owner']);
     $url = 'https://flic.kr/p/' . \Samwilson\PhpFlickr\Util::base58encode($photo['id']);
     echo "<li> Photo: <a href='$url'>" . $photo['title'] . "</a>";
     echo "; Owner: ";

--- a/examples/unauthenticated_requests.php
+++ b/examples/unauthenticated_requests.php
@@ -21,6 +21,6 @@ $flickr = new \Samwilson\PhpFlickr\PhpFlickr($apiKey);
 
 // Get the 10 most recent photos, with URLs for their 'small' size.
 // For details of the size suffixes, see https://www.flickr.com/services/api/misc.urls.html
-$recent = $flickr->photosGetRecent(['url_s'], 10);
+$recent = $flickr->photos()->getRecent(['url_s'], 10);
 
 print_r($recent);

--- a/src/PeopleApi.php
+++ b/src/PeopleApi.php
@@ -75,7 +75,8 @@ class PeopleApi extends ApiMethodGroup
         $params = [
             'user_id' => $userId
         ];
-        return $this->flickr->request('flickr.people.getInfo', $params);
+        $response = $this->flickr->request('flickr.people.getInfo', $params);
+        return isset($response['person']) ? $response['person'] : null;
     }
 
     /**

--- a/src/PhpFlickr.php
+++ b/src/PhpFlickr.php
@@ -23,11 +23,8 @@
 namespace Samwilson\PhpFlickr;
 
 use DateInterval;
-use DateTime;
-use Exception;
 use OAuth\Common\Consumer\Credentials;
 use OAuth\Common\Http\Client\CurlClient;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Storage\Memory;
 use OAuth\Common\Storage\TokenStorageInterface;


### PR DESCRIPTION
* Return PeopleApi::getInfo() to its previous structure.
* Remove deprecated methods.
* Remove unused use statements.