### PR TITLE
get tests working with PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         # All supported PHP versions https://www.php.net/supported-versions.php
-        php: [ '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '8.2','8.3','8.4' ]
 
     runs-on: ${{matrix.os}}
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ This method doesn't allow for setting any photo metadata,
 but you can do the replacement asynchronously
 (in which case a 'ticket ID' will be returned).
 
+## User Agent
+
+If you are using PhpFlickr in an application, it is a good idea to set a custom user agent.
+This can be done with the following:
+
+```php
+$flickr->setUserAgent('MyVendor-MyApp/1.0.0');
+```
+
 ## Proxy server
 
 PhpFlickr can be used with a proxy server

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
 		"squizlabs/php_codesniffer": "^3.0",
 		"mediawiki/minus-x": "^0.3 || ^1.0",
 		"phpunit/phpunit": "^9.5",
-		"symfony/cache": "^5.4",
-		"symfony/var-dumper": "^5.4",
+		"symfony/cache": "^5.4|^6.4|^7.0",
+		"symfony/var-dumper": "^5.4|^6.4|^7.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"phan/phan": "^5.4"
 	},

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	},
 	"require": {
-		"php": "^7.3 || ^8.0",
+		"php": "^8.2",
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-libxml": "*",

--- a/src/Oauth/PhpFlickrService.php
+++ b/src/Oauth/PhpFlickrService.php
@@ -21,7 +21,7 @@ class PhpFlickrService extends Flickr
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,
-        UriInterface $baseApiUri = null
+        ?UriInterface $baseApiUri = null
     ) {
         if ($baseApiUri === null) {
             $baseApiUri = new Uri(static::$baseUrl . '/rest/');

--- a/src/PhotosApi.php
+++ b/src/PhotosApi.php
@@ -847,9 +847,9 @@ class PhotosApi extends ApiMethodGroup
      */
     public function setDates(
         $photoId,
-        DateTime $dateTaken = null,
+        DateTime|null $dateTaken = null,
         $dateTakenGranularity = null,
-        DateTime $datePosted = null
+        DateTime|null $datePosted = null
     ) {
         $args = ['photo_id' => $photoId];
         if (!empty($dateTaken)) {

--- a/src/PhpFlickr.php
+++ b/src/PhpFlickr.php
@@ -37,6 +37,9 @@ use Samwilson\PhpFlickr\Oauth\PhpFlickrService;
 
 class PhpFlickr
 {
+    /** PhpFlickr version. */
+    public const VERSION = '5.1.0';
+
     /** @param string */
     protected $api_key;
 
@@ -71,6 +74,9 @@ class PhpFlickr
     /** @var TokenStorageInterface */
     protected $oauthTokenStorage;
 
+    /** @var string The User Agent string to send to the Flickr API. */
+    protected $userAgent;
+
     /**
      * @param string $apiKey
      * @param string|null $secret
@@ -79,6 +85,7 @@ class PhpFlickr
     {
         $this->api_key = $apiKey;
         $this->secret = $secret;
+        $this->userAgent = 'PhpFlickr/' . self::VERSION . ' https://github.com/samwilson/phpflickr';
     }
 
     /**
@@ -158,6 +165,24 @@ class PhpFlickr
     }
 
     /**
+     * Set the User Agent string that will be sent to Flickr.
+     * Should be of the form `product/product-version comment`.
+     * @param string $userAgent
+     */
+    public function setUserAgent(string $userAgent): void
+    {
+        $this->userAgent = $userAgent;
+    }
+
+    /**
+     * Get the User Agent string.
+     */
+    public function getUserAgent(): string
+    {
+        return $this->userAgent;
+    }
+
+    /**
      * Send a POST request to the Flickr API.
      * @param string $command The API endpoint to call.
      * @param string[] $args The API request arguments.
@@ -178,7 +203,10 @@ class PhpFlickr
         if (!($this->response) || $nocache) {
             $args = array_filter($args);
             $oauthService = $this->getOauthService();
-            $this->response = $oauthService->requestJson($command, 'POST', $args);
+            $extraHeaders = [
+                'User-Agent' => $this->getUserAgent(),
+            ];
+            $this->response = $oauthService->requestJson($command, 'POST', $args, $extraHeaders);
             if (!$nocache) {
                 $this->cache($request, $this->response);
             }

--- a/src/PhpFlickr.php
+++ b/src/PhpFlickr.php
@@ -81,7 +81,7 @@ class PhpFlickr
      * @param string $apiKey
      * @param string|null $secret
      */
-    public function __construct(string $apiKey, string $secret = null)
+    public function __construct(string $apiKey, string|null $secret = null)
     {
         $this->api_key = $apiKey;
         $this->secret = $secret;

--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -111,6 +111,7 @@ class Uploader
         curl_setopt($curl, CURLOPT_POST, true);
         curl_setopt($curl, CURLOPT_POSTFIELDS, $args);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_USERAGENT, $this->flickr->getUserAgent());
         $response = curl_exec($curl);
         $this->response = $response;
         curl_close($curl);

--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -12,6 +12,7 @@ class Uploader
     /** @var PhpFlickr */
     protected $flickr;
 
+    protected $response;
     /** @var string */
     protected $uploadEndpoint = 'https://up.flickr.com/services/upload/';
 


### PR DESCRIPTION
I'm not sure how to have the same codebase work for both php 7 and php 8.4, so I dropped all the unsupported versions of PHP and tweaked the calls that PHP 8.4 complained about.