### PR TITLE
Check for photoset's `has_requested_photos` before using

### DIFF
--- a/src/PhotosApi.php
+++ b/src/PhotosApi.php
@@ -474,7 +474,8 @@ class PhotosApi extends ApiMethodGroup
             }
             foreach ($sets['photoset'] as $photoset) {
                 foreach ($photoIds as $photoId) {
-                    if (in_array($photoId, $photoset['has_requested_photos'])) {
+                    // has_requested_photos is only set if the user owns the photo.
+                    if (in_array($photoId, $photoset['has_requested_photos'] ?? [])) {
                         $out[] = $photoset;
                     }
                 }


### PR DESCRIPTION
Only photos owned by the user will be returned in has_requested_photos, otherwise the data is left off. This was resulting in the following error:

> Fatal error: Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given